### PR TITLE
chore: bump webweg version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "webreg_scraper"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "axum-macros",
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "webweg"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ead3d6f448758f373ce4718898b72288f84f9f049d530a0be9aa13cd2dd1d87"
+checksum = "72705f8fe955fde189796b69a34ced1575070bb3a8de0ce40f87394be8a48d0d"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webreg_scraper"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Edward Wang"]
 edition = "2021"
 description = "A scraper and/or API for UC San Diego's WebReg enrollment system."
@@ -12,7 +12,7 @@ repository = "https://github.com/ewang2002/webreg_scraper"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros", "signal"] }
-webweg = "0.7.1"
+webweg = "0.7.2"
 chrono = "0.4.19"
 once_cell = "1.10.0"
 axum = { version = "0.6.1", optional = true }


### PR DESCRIPTION
Bumps `webweg` to `0.7.2`. 