### PR TITLE
v0.7.4: Bump webweg Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "webweg"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72705f8fe955fde189796b69a34ced1575070bb3a8de0ce40f87394be8a48d0d"
+checksum = "ee9d74b38af68ab46f39473d80a96978bbc7c3037888a87ec20694a5e94a5c20"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webreg_scraper"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Edward Wang"]
 edition = "2021"
 description = "A scraper and/or API for UC San Diego's WebReg enrollment system."
@@ -12,7 +12,7 @@ repository = "https://github.com/ewang2002/webreg_scraper"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros", "signal"] }
-webweg = "0.7.2"
+webweg = "0.7.4"
 chrono = "0.4.19"
 once_cell = "1.10.0"
 axum = { version = "0.6.1", optional = true }


### PR DESCRIPTION
This PR simply bumps webweg's version to 0.7.4 (from 0.7.2). 