### PR TITLE
[0.5.0] Single Cookie Support & More Endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "authmanager"
-version = "0.5.0-rc.4"
+version = "0.5.0"
 dependencies = [
  "basicauth",
  "clap",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "webreg"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/authmanager/Cargo.toml
+++ b/crates/authmanager/Cargo.toml
@@ -3,7 +3,7 @@ name = "authmanager"
 description = """
 A simple authentication manager that can be used to manage authorization tokens for the scraper's WebReg API.
 """
-version = "0.5.0-rc.4"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/webreg/Cargo.toml
+++ b/crates/webreg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webreg"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 authors = ["Edward Wang"]
 edition = "2021"
 description = "A scraper and API for UC San Diego's WebReg enrollment system."


### PR DESCRIPTION
This PR is simply a version change -- see [rc1](https://github.com/ewang2002/webreg_scraper/pull/25), [rc2](https://github.com/ewang2002/webreg_scraper/pull/26), [rc3](https://github.com/ewang2002/webreg_scraper/pull/27), [rc4](https://github.com/ewang2002/webreg_scraper/pull/29), and [rc5](https://github.com/ewang2002/webreg_scraper/pull/30) for full changes.

## Summary
- Update scraper so that only one cookie is needed for all terms being scraped.
- Add support for terms that are available, but hidden, on WebReg. 
- Add support for course and section text endpoints.
- Add support for raw response data from WebReg for select endpoints.
